### PR TITLE
fix: add right and left column data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6028,11 +6028,6 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
     },
-    "highlight.js": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.0.tgz",
-      "integrity": "sha512-EfrUGcQ63oLJbj0J0RI9ebX6TAITbsDBLbsjr881L/X5fMO9+oadKzEF21C7R3ULKG6Gv3uoab2HiqVJa/4+oA=="
-    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -8187,6 +8182,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "core-js": "^3.4.7",
-    "highlight.js": "^10.4.0",
+    "moment": "^2.29.1",
     "regenerator-runtime": "^0.13.3"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -2,8 +2,15 @@ import './css/style.css';
 
 import getSummaryDataCovid from './js/getSummaryDataCovid';
 import Country from './js/country';
+import searchItem from './js/search';
+import checkCountryClicked from './js/hundlerCountry';
+import rightColumnClickedHundler from './js/rightHundler';
 
 const getDataCountry = new Country();
 getDataCountry.getDataCountry();
+const allCountry = getDataCountry.allCountry;
 
-getSummaryDataCovid();
+getSummaryDataCovid(allCountry);
+searchItem();
+checkCountryClicked(allCountry);
+rightColumnClickedHundler(allCountry);

--- a/src/js/country.js
+++ b/src/js/country.js
@@ -1,6 +1,7 @@
 export default class Country {
   constructor() {
-    
+    this.mainList = document.querySelector('.left-column-list-content');
+    this.allCountry = [];
   }
 
   getDataCountry() {
@@ -9,7 +10,49 @@ export default class Country {
         return response.json();
       })
       .then((data) => {
-        console.log(data);
+        this.createAllCountryItemsList(data);
       });
+  }
+
+  createAllCountryItemsList(data) {
+    data.forEach(element => {
+      const item = {
+        // eslint-disable-next-line no-underscore-dangle
+        id: element.countryInfo._id,
+        updated: element.updated,
+        name: element.country,
+        flag: element.countryInfo.flag,
+        latitude: element.countryInfo.lat,
+        longitude: element.countryInfo.long,
+        population: element.population,
+        cases: element.cases,
+        deaths: element.deaths,
+        recovered: element.recovered,
+        todayCases: element.todayCases,
+        todayDeaths: element.todayDeaths,
+        todayRecovered: element.todayRecovered
+      };
+      this.allCountry.push(item);
+    });
+    this.addDomTemplate();
+    console.log(this.allCountry);
+  }
+
+  addDomTemplate() {
+    this.allCountry.sort((a, b) => b.cases - a.cases);
+    this.allCountry.forEach((element, index) => {
+      const template = `
+        <div class="left-column-item" data-id="${element.id}">
+          <div class="list-country">
+            <p class="list-number">${index + 1}. </p>
+            <p class="list-flag"><img src="${element.flag}" alt="flag"></p>
+            <p class="list-country-name">${element.name}</p>
+          </div>
+          <p class="list-death">${element.cases}</p>
+        </div>
+      `;
+      this.mainList.innerHTML += template;
+    });
+    document.querySelector('.left-column-total-count').textContent = this.allCountry.length;
   }
 }

--- a/src/js/getSummaryDataCovid.js
+++ b/src/js/getSummaryDataCovid.js
@@ -1,8 +1,39 @@
-async function getSummaryDataCovid() {
-  const url = 'https://api.covid19api.com/summary';
-  const res = await fetch(url);
-  const data = await res.json();
-  console.log(data);
+import moment from 'moment';
+
+const headerTotalDeath = document.querySelector('.header-death-count');
+const globalTotalCount = document.querySelector('.main-total-count');
+const footerDate = document.querySelector('.footer-date-count');
+const rightColumnDeath = document.querySelector('.right-column-total-title');
+const rightColumnTotalCount = document.querySelector('.right-column-total-count');
+
+function getSummaryDataCovid(data) {
+  setTimeout(() => {
+    footerDate.textContent = `${moment(data[0].updated).format('DD MMM YYYY')}`;
+    const totalDeath = data.reduce((acc, cur) => acc + cur.deaths, 0);
+    const totalCases = data.reduce((acc, cur) => acc + cur.cases, 0);
+    headerTotalDeath.append(totalDeath);
+    globalTotalCount.append(totalCases);
+    rightColumnDeath.textContent = 'Global Death';
+    rightColumnTotalCount.textContent = totalDeath;
+    const sortData = data.sort((a, b) => b.deaths - a.deaths);
+    createTemplate(sortData);
+  }, 300);
+}
+
+function createTemplate(data) {
+  const countryList = document.querySelector('.right-column-total-list');
+  data.forEach((item, index) => {
+    const template = `
+      <div class="right-column-item">
+        <div class="right-country">
+          <p class="right-number">${index + 1}. </p>
+          <p class="right-country-name">${item.name}</p>
+        </div>
+        <p class="right-death">${item.deaths}</p>
+      </div>
+    `;
+    countryList.innerHTML += template;
+  });
 }
 
 export default getSummaryDataCovid;

--- a/src/js/hundlerCountry.js
+++ b/src/js/hundlerCountry.js
@@ -1,0 +1,10 @@
+function checkCountryClicked(data) {
+  const allCountryList = document.querySelector('.left-column-list-content');
+  allCountryList.addEventListener('click', (e) => {
+    const target = e.target;
+    const clickCountry = data.find(item => item.id === +target.dataset.id);
+    console.log(clickCountry);
+  });
+}
+
+export default checkCountryClicked;

--- a/src/js/rightHundler.js
+++ b/src/js/rightHundler.js
@@ -1,0 +1,74 @@
+const title = document.querySelector('.right-column-total-title');
+const count = document.querySelector('.right-column-total-count');
+const countryList = document.querySelector('.right-column-total-list');
+
+function rightColumnClickedHundler(data) {
+  const rightSlider = document.querySelector('.right-column-slider');
+  const rightSliderLinks = [...document.querySelectorAll('.right-column-global-link')];
+
+  rightSlider.addEventListener('click', (e) => {
+    const block = document.querySelector('.right-column-total-content');
+    const target = e.target;
+    rightSliderLinks.forEach(item => {
+      item.classList.remove('border-top');
+    });
+    target.classList.add('border-top');
+    if (target.innerText === 'Global recovery') {
+      block.classList.add('color-green');
+      createDomRecovery(data);
+    } else {
+      block.classList.remove('color-green');
+      createDomDeaths(data);
+    }
+  });
+}
+
+function createDomDeaths(data) {
+  title.textContent = 'Global Death';
+  const allCountDeaths = data.reduce((acc, cur) => acc + cur.deaths, 0);
+  count.innerText = allCountDeaths;
+  const sortData = data.sort((a, b) => b.deaths - a.deaths);
+  const newData = [];
+  sortData.forEach(element => {
+    const item = {
+      country: element.name,
+      count: element.deaths
+    };
+    newData.push(item);
+  });
+  createTemplate(newData);
+}
+
+function createDomRecovery(data) {
+  title.textContent = 'Global Recovery';
+  const allCountRecovered = data.reduce((acc, cur) => acc + cur.recovered, 0);
+  count.innerText = allCountRecovered;
+  const sortData = data.sort((a, b) => b.recovered - a.recovered);
+  const newData = [];
+  sortData.forEach(element => {
+    const item = {
+      country: element.name,
+      count: element.recovered
+    };
+    newData.push(item);
+  });
+  createTemplate(newData);
+}
+
+function createTemplate(data) {
+  countryList.innerHTML = '';
+  data.forEach((item, index) => {
+    const template = `
+      <div class="right-column-item">
+        <div class="right-country">
+          <p class="right-number">${index + 1}. </p>
+          <p class="right-country-name">${item.country}</p>
+        </div>
+        <p class="right-death">${item.count}</p>
+      </div>
+    `;
+    countryList.innerHTML += template;
+  });
+}
+
+export default rightColumnClickedHundler;

--- a/src/js/search.js
+++ b/src/js/search.js
@@ -1,0 +1,15 @@
+export default function searchItem() {
+  const input = document.querySelector('.left-column-form-input');
+
+  input.oninput = function changeInput() {
+    const allCountyToList = [...document.querySelectorAll('.left-column-item')];
+    let val = this.value.trim().toUpperCase();
+    allCountyToList.forEach(element => {
+      if (element.children[0].children[2].innerText.toUpperCase().search(val) === -1) {
+        element.classList.add('hide');
+      } else {
+        element.classList.remove('hide');
+      }
+    });
+  };
+}


### PR DESCRIPTION
Изменил функции получения данных по КОВИД. Теперь всё идёт из одного запроса. Глобальные данные (общие показатели смертей и случаев - высчитывается через reduce. Так данные получаются самые актуальные и нет проблем с данными для карт и флагами (быстрее стало работать).
Вывел список справа и слева. Слева общий список с флагом и количеством случаев. Также сделал поиск. Над ним надо ещё чуть поработать, чтобы можно было как-то с данными которые приходят по клику - взаимодействовать, пока выводит кликабельный элемент в консоль, что с ним делать потом - решим.
Справа две ячейки (по смертям и по выздоровлениям) если есть моменты - пишите.